### PR TITLE
Reduce initial heap size

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     --no-entry
     -s WASM=1
     -s ENVIRONMENT="web"
+    -s INITIAL_HEAP=262144
     -s ALLOW_MEMORY_GROWTH=1
     -s NO_FILESYSTEM=1
     -s NO_DISABLE_EXCEPTION_CATCHING=1


### PR DESCRIPTION
Closes https://github.com/hypervideo/hyper.video/issues/3356.

Reduce from the default 16 MiB to 256 KiB, which should be plenty.

For reference, the max decode output buffer size is 5760 (max frame size) * 2 (stereo) * 4 (f32) = ~46 KB. Currently, we only allocate one such buffer for the output, another strictly smaller one for the decoder input, and for the decoder struct itself.